### PR TITLE
INTYG-5575: New tests for DOI - Validation R22 for terminal dodsorsak datum

### DIFF
--- a/intyg/clinicalprocess-healthcond-certificate-schematron/src/main/resources/doi.sch
+++ b/intyg/clinicalprocess-healthcond-certificate-schematron/src/main/resources/doi.sch
@@ -217,6 +217,12 @@
   <iso:pattern id="q8.2">
     <iso:rule context="//gn:delsvar[@id='8.2']">
       <iso:extends rule="date"/>
+      <iso:assert test="not(//gn:delsvar[@id='2.2'] castable as xs:date) or xs:date(.) le xs:date(//gn:delsvar[@id='2.2'])">
+        'Datum terminal dödsorsak' får inte vara efter 'Om dödsdatum'
+      </iso:assert>
+      <iso:assert test="not(//gn:delsvar[@id='2.3'] castable as xs:date) or xs:date(.) le xs:date(//gn:delsvar[@id='2.3'])">
+        'Datum terminal dödsorsak' får inte vara efter 'Anträffat död'
+      </iso:assert>
     </iso:rule>
   </iso:pattern>
 


### PR DESCRIPTION
[INTYG-5575](https://inera-certificate.atlassian.net/browse/INTYG-5575) - Uppdatering i schema för validering av datum för terminal dödsorsak i DOI. 

Motsvarande feature branch och pull request finns i [common](https://github.com/sklintyg/common).

