### PR TITLE
DEVENV: Fixed broken codeQuality check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,9 @@
 plugins {
-    id "se.inera.intyg.plugin.common" version "1.0.70" apply false
+    id "se.inera.intyg.plugin.common" version "2.0.3" apply false
     id "no.nils.wsdl2java" version "0.10" apply false
 }
+
+
 
 allprojects {
     apply plugin: 'se.inera.intyg.plugin.common'
@@ -14,6 +16,12 @@ allprojects {
         logbackVersion = "1.0.11"
         // Errorprone has no mechanism (yet) for excluding generated code. We hence only use it for 'schemas-support'.
         errorproneExclude = ".*-schemas\$"
+    }
+
+    if (project.hasProperty("codeQuality")) {
+        license {
+            exclude "**/*.java" // Exclude all.
+        }
     }
 
     repositories {
@@ -57,6 +65,7 @@ allprojects {
         }
     }
 }
+
 
 configure(subprojects.findAll { !['support', 'intyg-clinicalprocess-healthcond-certificate-schematron'].contains(it.name) }) {
     dependencies {


### PR DESCRIPTION
Upptäckte att ocdeQuality inte längre fungerade när release 2.1.8 av schemas-contract skulle byggas. Detta är nu fixat och passade samtidigt på och snyggade till multitråd-testet.

Licensheader checken falerar för generead kod, och är därför avstängd för java klasser. Hittade tyvärr ingen metod att fixa detta på ett mer fingranulärt sätt (och samma mönster har använts i andra projekt med samma behov). 